### PR TITLE
Fix for issue #7 about syntax highlighting

### DIFF
--- a/grammars/x86-assembly.cson
+++ b/grammars/x86-assembly.cson
@@ -130,7 +130,7 @@
     'name': 'keyword.mnemonic'
   }
   {
-    'match': '%?(ip|eip|eax|ebx|ecx|edx|edi|esi|ebp|esp|ax|bx|cx|dx|di|si|bp|sp|ah|al|bh|bl|ch|cl|dh|dl|ax|bx|cx|dx|rax|rbx|rcx|rdx|rdi|rsi|rbp|rsp|cs|ds|ss|es|fs|gs|cr0|cr2|cr3|cr4|db0|db1|db2|db3|db6|db7|dr0|dr1|dr2|dr3|dr4|dr5|dr6|dr7|tr6|tr7|r0|r1|r2|r3|r4|r5|r6|r7|r8|r9|r10|r11|r12|r13|r14|r15|r0d|r1d|r2d|r3d|r4d|r5d|r6d|r7d|r8d|r9d|r10d|r11d|r12d|r13d|r14d|r15d|r0w|r1w|r2w|r3w|r4w|r5w|r6w|r7w|r8w|r9w|r10w|r11w|r12w|r13w|r14w|r15w|r0l|r1l|r2l|r3l|r4l|r5l|r6l|r7l|r8l|r9l|r10l|r11l|r12l|r13l|r14l|15l|st)+\\b'
+    'match': '\\b%?(ip|eip|eax|ebx|ecx|edx|edi|esi|ebp|esp|ax|bx|cx|dx|di|si|bp|sp|ah|al|bh|bl|ch|cl|dh|dl|ax|bx|cx|dx|rax|rbx|rcx|rdx|rdi|rsi|rbp|rsp|cs|ds|ss|es|fs|gs|cr0|cr2|cr3|cr4|db0|db1|db2|db3|db6|db7|dr0|dr1|dr2|dr3|dr4|dr5|dr6|dr7|tr6|tr7|r0|r1|r2|r3|r4|r5|r6|r7|r8|r9|r10|r11|r12|r13|r14|r15|r0d|r1d|r2d|r3d|r4d|r5d|r6d|r7d|r8d|r9d|r10d|r11d|r12d|r13d|r14d|r15d|r0w|r1w|r2w|r3w|r4w|r5w|r6w|r7w|r8w|r9w|r10w|r11w|r12w|r13w|r14w|r15w|r0l|r1l|r2l|r3l|r4l|r5l|r6l|r7l|r8l|r9l|r10l|r11l|r12l|r13l|r14l|15l|st)+\\b'
     'name': 'storage.register'
   }
   {


### PR DESCRIPTION
Add `\\b` to beginning of string in line 133.

Issue #7 
